### PR TITLE
v5: structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .git/
 .idea/
-slocLoader.sln.DotSettings.user
+*.user
 slocLoader/bin/
 slocLoader/obj/
 slocLoader.NWAPI/bin/

--- a/slocLoader.NWAPI/API.Create.cs
+++ b/slocLoader.NWAPI/API.Create.cs
@@ -222,7 +222,8 @@ public static partial class API
                 kvp.Key.AddTriggerAction(new RuntimeTeleportToSpawnedObjectData(target, data.Offset)
                 {
                     SelectedTargets = data.SelectedTargets,
-                    Options = data.Options
+                    Options = data.Options,
+                    RotationY = data.RotationY
                 }, handler);
         }
     }

--- a/slocLoader.NWAPI/API.Create.cs
+++ b/slocLoader.NWAPI/API.Create.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using MapGeneration.Distributors;
+using Mirror;
 using slocLoader.ObjectCreation;
 using slocLoader.Objects;
 using slocLoader.TriggerActions;
@@ -63,10 +64,12 @@ public static partial class API
     {
         if (!StructurePrefabIds.TryGetValue(structure.Structure, out var id) || !NetworkClient.prefabs.TryGetValue(id, out var prefab))
             return null;
-        var gameObject = Object.Instantiate(prefab);
-        gameObject.SetAbsoluteTransformFrom(parent);
-        gameObject.SetLocalTransform(structure.Transform);
-        return gameObject;
+        var o = Object.Instantiate(prefab);
+        o.SetAbsoluteTransformFrom(parent);
+        o.SetLocalTransform(structure.Transform);
+        if (structure.RemoveDefaultLoot && o.TryGetComponent(out Locker locker))
+            locker.Loot = Array.Empty<LockerLoot>();
+        return o;
     }
 
     private static GameObject CreatePrimitive(GameObject parent, PrimitiveObject primitive)

--- a/slocLoader.NWAPI/API.Create.cs
+++ b/slocLoader.NWAPI/API.Create.cs
@@ -67,6 +67,7 @@ public static partial class API
         var o = Object.Instantiate(prefab);
         o.SetAbsoluteTransformFrom(parent);
         o.SetLocalTransform(structure.Transform);
+        o.AddComponent<slocObjectData>();
         if (structure.RemoveDefaultLoot && o.TryGetComponent(out Locker locker))
             locker.Loot = Array.Empty<LockerLoot>();
         return o;

--- a/slocLoader.NWAPI/API.Read.cs
+++ b/slocLoader.NWAPI/API.Read.cs
@@ -8,14 +8,15 @@ public static partial class API
 
     #region Reader Declarations
 
-    public static readonly IObjectReader DefaultReader = new Ver4Reader();
+    public static readonly IObjectReader DefaultReader = new Ver5Reader();
 
     private static readonly Dictionary<ushort, IObjectReader> VersionReaders = new()
     {
         {1, new Ver1Reader()},
         {2, new Ver2Reader()},
         {3, new Ver3Reader()},
-        {4, new Ver4Reader()}
+        {4, new Ver4Reader()},
+        {5, DefaultReader}
     };
 
     public static bool TryGetReader(ushort version, out IObjectReader reader) => VersionReaders.TryGetValue(version, out reader);

--- a/slocLoader.NWAPI/API.Spawn.cs
+++ b/slocLoader.NWAPI/API.Spawn.cs
@@ -37,7 +37,7 @@ public static partial class API
         if (o == null)
         {
             if (throwOnError)
-                throw new ArgumentOutOfRangeException(nameof(obj.Type), obj.Type, "Unknown object type");
+                throw new ArgumentOutOfRangeException(nameof(obj), $"Failed to create object of type {obj.Type}");
             return null;
         }
 

--- a/slocLoader.NWAPI/API.cs
+++ b/slocLoader.NWAPI/API.cs
@@ -13,7 +13,7 @@ namespace slocLoader;
 public static partial class API
 {
 
-    public const ushort slocVersion = 4;
+    public const ushort slocVersion = 5;
 
     public const float ColorDivisionMultiplier = 1f / 255f;
 

--- a/slocLoader.NWAPI/Commands/ReloadCommand.cs
+++ b/slocLoader.NWAPI/Commands/ReloadCommand.cs
@@ -4,6 +4,7 @@ using slocLoader.AutoObjectLoader;
 namespace slocLoader.Commands;
 
 [CommandHandler(typeof(GameConsoleCommandHandler))]
+[CommandHandler(typeof(RemoteAdminCommandHandler))]
 public sealed class ReloadCommand : ICommand
 {
 
@@ -13,6 +14,12 @@ public sealed class ReloadCommand : ICommand
 
     public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
     {
+        if (!sender.CheckPermission(PlayerPermissions.ServerConfigs))
+        {
+            response = "You don't have permission to do that (ServerConfigs)!";
+            return false;
+        }
+
         AutomaticObjectLoader.LoadObjects();
         response = "Reload complete.";
         return true;

--- a/slocLoader.NWAPI/Commands/StructureCommand.cs
+++ b/slocLoader.NWAPI/Commands/StructureCommand.cs
@@ -1,0 +1,60 @@
+﻿using CommandSystem;
+using Mirror;
+using RemoteAdmin;
+using slocLoader.Objects;
+
+namespace slocLoader.Commands;
+
+[CommandHandler(typeof(RemoteAdminCommandHandler))]
+public sealed class StructureCommand : ICommand, IUsageProvider
+{
+
+    public string[] Usage { get; } = {"type"};
+    public string Command => "sl_structure";
+    public string[] Aliases => Array.Empty<string>();
+    public string Description => "Spawns the specified structure type.";
+
+    public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+    {
+        var p = Player.Get((sender as PlayerCommandSender)?.ReferenceHub);
+        if (p == null)
+        {
+            response = "You must be a player to execute this command!";
+            return false;
+        }
+
+        if (!sender.CheckPermission(PlayerPermissions.FacilityManagement))
+        {
+            response = "You don't have permission to do that (FacilityManagement)!";
+            return false;
+        }
+
+        if (arguments.Count < 1)
+        {
+            response = "Usage: sl_structure <structure type>";
+            return false;
+        }
+
+        if (!arguments.ParseEnumIgnoreCase(out StructureObject.StructureType type))
+        {
+            response = "Unknown structure type.\nValid types: " + string.Join(", ", Enum.GetNames(typeof(StructureObject.StructureType)));
+            return false;
+        }
+
+        var position = PositionCommand.Defined.TryGetValue(p.UserId, out var pos) ? pos : p.Position;
+        var rotation = RotationCommand.Defined.TryGetValue(p.UserId, out var rot)
+            ? rot
+            : new Quaternion(0, p.ReferenceHub.PlayerCameraReference.rotation.y, 0, 1);
+        var go = new StructureObject(type)
+        {
+            Transform =
+            {
+                Position = position,
+                Rotation = rotation
+            }
+        }.SpawnObject();
+        response = $"Spawned {type} with NetID: {go.GetComponent<NetworkIdentity>().netId}";
+        return true;
+    }
+
+}

--- a/slocLoader.NWAPI/Objects/ObjectType.cs
+++ b/slocLoader.NWAPI/Objects/ObjectType.cs
@@ -11,6 +11,7 @@ public enum ObjectType : byte
     Cylinder = 5,
     Plane = 6,
     Quad = 7,
-    Empty = 8
+    Empty = 8,
+    Structure = 9
 
 }

--- a/slocLoader.NWAPI/Objects/StructureObject.cs
+++ b/slocLoader.NWAPI/Objects/StructureObject.cs
@@ -1,0 +1,52 @@
+﻿using slocLoader.Readers;
+
+namespace slocLoader.Objects;
+
+public sealed class StructureObject : slocGameObject
+{
+
+    public StructureObject(StructureType structureType) : this(0, structureType)
+    {
+    }
+
+    public StructureObject(int instanceId, StructureType structureType) : base(instanceId)
+    {
+        Type = ObjectType.Structure;
+        Structure = structureType;
+    }
+
+    public StructureType Structure { get; set; }
+
+    public override bool IsValid => Structure != StructureType.None;
+
+    protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+
+    public enum StructureType : byte
+    {
+
+        None = 0,
+        Adrenaline = 1,
+        BinaryTarget = 2,
+        DboyTarget = 3,
+        EzBreakableDoor = 4,
+        Generator = 5,
+        HczBreakableDoor = 6,
+        LczBreakableDoor = 7,
+        LargeGunLocker = 8,
+        MiscellaneousLocker = 9,
+        Medkit = 10,
+        RifleRack = 11,
+        Scp018Pedestal = 12,
+        Scp207Pedestal = 13,
+        Scp244Pedestal = 14,
+        Scp268Pedestal = 15,
+        Scp500Pedestal = 16,
+        Scp1576Pedestal = 17,
+        Scp1853Pedestal = 18,
+        Scp2176Pedestal = 19,
+        SportTarget = 20,
+        Workstation = 21
+
+    }
+
+}

--- a/slocLoader.NWAPI/Objects/StructureObject.cs
+++ b/slocLoader.NWAPI/Objects/StructureObject.cs
@@ -5,6 +5,8 @@ namespace slocLoader.Objects;
 public sealed class StructureObject : slocGameObject
 {
 
+    public const int RemoveDefaultLootBit = 0b1000_0000;
+
     public StructureObject(StructureType structureType) : this(0, structureType)
     {
     }
@@ -17,9 +19,12 @@ public sealed class StructureObject : slocGameObject
 
     public StructureType Structure { get; set; }
 
+    public bool RemoveDefaultLoot { get; set; }
+
     public override bool IsValid => Structure != StructureType.None;
 
-    protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+    protected override void WriteData(BinaryWriter writer, slocHeader header)
+        => writer.Write((byte) ((int) Structure | (RemoveDefaultLoot ? RemoveDefaultLootBit : 0)));
 
     public enum StructureType : byte
     {

--- a/slocLoader.NWAPI/Properties/AssemblyInfo.cs
+++ b/slocLoader.NWAPI/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.4.0")]
-[assembly: AssemblyFileVersion("4.2.4.0")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]

--- a/slocLoader.NWAPI/Readers/Ver5Reader.cs
+++ b/slocLoader.NWAPI/Readers/Ver5Reader.cs
@@ -1,0 +1,44 @@
+﻿using slocLoader.Objects;
+
+namespace slocLoader.Readers
+{
+
+    public sealed class Ver5Reader : IObjectReader
+    {
+
+        public slocHeader ReadHeader(BinaryReader stream) => Ver3Reader.ReadHeaderStatic(stream, 5);
+
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
+            var objectType = (ObjectType) stream.ReadByte();
+            return objectType switch
+            {
+                ObjectType.Structure => ReadStructure(stream),
+                ObjectType.Cube
+                    or ObjectType.Sphere
+                    or ObjectType.Cylinder
+                    or ObjectType.Plane
+                    or ObjectType.Capsule
+                    or ObjectType.Quad => Ver4Reader.ReadPrimitive(stream, objectType, header),
+                ObjectType.Light => Ver3Reader.ReadLight(stream, header),
+                ObjectType.Empty => Ver2Reader.ReadEmpty(stream),
+                _ => null
+            };
+        }
+
+        public static StructureObject ReadStructure(BinaryReader stream)
+        {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var structureType = (StructureObject.StructureType) stream.ReadByte();
+            return new StructureObject(instanceId, structureType)
+            {
+                ParentId = parentId,
+                Transform = transform
+            };
+        }
+
+    }
+
+}

--- a/slocLoader.NWAPI/Readers/Ver5Reader.cs
+++ b/slocLoader.NWAPI/Readers/Ver5Reader.cs
@@ -31,11 +31,12 @@ namespace slocLoader.Readers
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
-            var structureType = (StructureObject.StructureType) stream.ReadByte();
-            return new StructureObject(instanceId, structureType)
+            var typeData = stream.ReadByte();
+            return new StructureObject(instanceId, (StructureObject.StructureType) (typeData & ~StructureObject.RemoveDefaultLootBit))
             {
                 ParentId = parentId,
-                Transform = transform
+                Transform = transform,
+                RemoveDefaultLoot = (typeData & StructureObject.RemoveDefaultLootBit) != 0
             };
         }
 

--- a/slocLoader.NWAPI/SendSpawnMessagePatch.cs
+++ b/slocLoader.NWAPI/SendSpawnMessagePatch.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using Mirror;
+using static Axwabo.Helpers.Harmony.InstructionHelper;
+
+namespace slocLoader;
+
+[HarmonyPatch(typeof(NetworkServer), nameof(NetworkServer.SendSpawnMessage))]
+public static class SendSpawnMessagePatch
+{
+
+    public delegate void SpawnDataModifier(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message);
+
+    public static readonly List<SpawnDataModifier> SpawnDataModifiers = new List<SpawnDataModifier> {SetGlobalTransformForSlocObject};
+
+    public static void ModifySpawnMessage(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message)
+    {
+        foreach (var modifier in SpawnDataModifiers)
+            modifier(identity, connection, ref message);
+    }
+
+    private static void SetGlobalTransformForSlocObject(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message)
+    {
+        if (!identity.TryGetComponent(out slocObjectData _))
+            return;
+        var transform = identity.transform;
+        message.position = transform.position;
+        message.rotation = transform.rotation;
+        message.scale = transform.lossyScale;
+    }
+
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var list = new List<CodeInstruction>(instructions);
+        var index = list.FindCall(nameof(NetworkConnection.Send)) - 3;
+        list.InsertRange(index, new[]
+        {
+            Ldarg(0),
+            Ldarg(1),
+            Ldloca(4),
+            Call(ModifySpawnMessage)
+        });
+        return list;
+    }
+
+}

--- a/slocLoader.NWAPI/TriggerActions/ActionManager.cs
+++ b/slocLoader.NWAPI/TriggerActions/ActionManager.cs
@@ -38,7 +38,7 @@ public static class ActionManager
         TeleportOptions.ResetFallDamage,
         TeleportOptions.ResetVelocity,
         TeleportOptions.WorldSpaceTransform,
-        TeleportOptions.UseDeltaPlayerRotation
+        TeleportOptions.DeltaRotation
     }.AsReadOnly();
 
     private static readonly ITriggerActionHandler[] ActionHandlers =

--- a/slocLoader.NWAPI/TriggerActions/ActionManager.cs
+++ b/slocLoader.NWAPI/TriggerActions/ActionManager.cs
@@ -36,7 +36,8 @@ public static class ActionManager
     {
         TeleportOptions.ResetFallDamage,
         TeleportOptions.ResetVelocity,
-        TeleportOptions.WorldSpaceTransform
+        TeleportOptions.WorldSpacePosition,
+        TeleportOptions.WorldSpaceRotation
     }.AsReadOnly();
 
     private static readonly ITriggerActionHandler[] ActionHandlers =

--- a/slocLoader.NWAPI/TriggerActions/ActionManager.cs
+++ b/slocLoader.NWAPI/TriggerActions/ActionManager.cs
@@ -10,11 +10,12 @@ public static class ActionManager
 
     public const ushort MinVersion = 4;
 
-    private static readonly ITriggerActionDataReader DefaultReader = new Ver4ActionDataReader();
+    private static readonly ITriggerActionDataReader DefaultReader = new Ver5ActionDataReader();
 
     private static readonly Dictionary<ushort, ITriggerActionDataReader> Readers = new()
     {
-        {4, new Ver4ActionDataReader()}
+        {4, new Ver4ActionDataReader()},
+        {5, DefaultReader}
     };
 
     public static readonly ICollection<TargetType> TargetTypeValues = new List<TargetType>
@@ -81,8 +82,7 @@ public static class ActionManager
                 actions.Add(action);
         }
 
-        var array = actions.ToArray();
-        return array;
+        return actions.ToArray();
     }
 
     public static void ReadTypes(BinaryReader reader, out TriggerActionType actionType, out TargetType targetType, out TriggerEventType eventType)
@@ -118,7 +118,7 @@ public static class ActionManager
 
     public static bool HasFlagFast(this TeleportOptions options, TeleportOptions flag) => (options & flag) == flag;
 
-    public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.None || type.HasFlagFast(isType);
+    public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.All || type.HasFlagFast(isType);
 
     public static bool ContainsAnyOf(this TargetType type, TargetType multiple) => type is TargetType.All || TargetTypeValues.Any(targetType => type.HasFlagFast(targetType) && multiple.HasFlagFast(targetType));
 

--- a/slocLoader.NWAPI/TriggerActions/ActionManager.cs
+++ b/slocLoader.NWAPI/TriggerActions/ActionManager.cs
@@ -37,8 +37,8 @@ public static class ActionManager
     {
         TeleportOptions.ResetFallDamage,
         TeleportOptions.ResetVelocity,
-        TeleportOptions.WorldSpacePosition,
-        TeleportOptions.WorldSpaceRotation
+        TeleportOptions.WorldSpaceTransform,
+        TeleportOptions.UseDeltaPlayerRotation
     }.AsReadOnly();
 
     private static readonly ITriggerActionHandler[] ActionHandlers =

--- a/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
+++ b/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
@@ -27,7 +27,7 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     }
 
     public Vector3 ToWorldSpacePosition(Transform reference) =>
-        Options.HasFlag(TeleportOptions.WorldSpacePosition)
+        Options.HasFlag(TeleportOptions.WorldSpaceTransform)
             ? reference.position + Position
             : reference.TransformPoint(Position);
 
@@ -35,7 +35,7 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     {
         position = ToWorldSpacePosition(reference);
         rotation = Quaternion.Euler(0,
-            Options.HasFlag(TeleportOptions.WorldSpaceRotation)
+            Options.HasFlag(TeleportOptions.UseDeltaPlayerRotation)
                 ? RotationY
                 : reference.rotation.eulerAngles.y + RotationY,
             0);

--- a/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
+++ b/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
@@ -31,14 +31,12 @@ public abstract class BaseTeleportData : BaseTriggerActionData
             ? reference.position + Position
             : reference.TransformPoint(Position);
 
-    public void ToWorldSpace(Transform reference, out Vector3 position, out Quaternion rotation)
+    public void ToWorldSpace(Transform reference, out Vector3 position, out float rotation)
     {
         position = ToWorldSpacePosition(reference);
-        rotation = Quaternion.Euler(0,
-            Options.HasFlag(TeleportOptions.UseDeltaPlayerRotation)
-                ? RotationY
-                : reference.rotation.eulerAngles.y + RotationY,
-            0);
+        rotation = Options.HasFlag(TeleportOptions.WorldSpaceTransform)
+            ? RotationY
+            : reference.rotation.eulerAngles.y + RotationY;
     }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
+++ b/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
@@ -11,10 +11,14 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     [field: SerializeField]
     public TeleportOptions Options { get; set; }
 
+    [field: SerializeField]
+    public float RotationY { get; set; }
+
     protected sealed override void WriteData(BinaryWriter writer)
     {
         writer.WriteVector(Position);
         writer.Write((byte) Options);
+        writer.Write(RotationY);
         WriteAdditionalData(writer);
     }
 
@@ -23,8 +27,18 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     }
 
     public Vector3 ToWorldSpacePosition(Transform reference) =>
-        Options.HasFlag(TeleportOptions.WorldSpaceTransform)
+        Options.HasFlag(TeleportOptions.WorldSpacePosition)
             ? reference.position + Position
             : reference.TransformPoint(Position);
+
+    public void ToWorldSpace(Transform reference, out Vector3 position, out Quaternion rotation)
+    {
+        position = ToWorldSpacePosition(reference);
+        rotation = Quaternion.Euler(0,
+            Options.HasFlag(TeleportOptions.WorldSpaceRotation)
+                ? RotationY
+                : reference.rotation.eulerAngles.y + RotationY,
+            0);
+    }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
+++ b/slocLoader.NWAPI/TriggerActions/Data/BaseTeleportData.cs
@@ -9,7 +9,7 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     public Vector3 Position { get; set; }
 
     [field: SerializeField]
-    public TeleportOptions Options { get; set; }
+    public TeleportOptions Options { get; set; } = TeleportOptions.ResetFallDamage | TeleportOptions.DeltaRotation;
 
     [field: SerializeField]
     public float RotationY { get; set; }

--- a/slocLoader.NWAPI/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
+++ b/slocLoader.NWAPI/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
@@ -13,13 +13,20 @@ public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionD
 
     public readonly Vector3 Offset;
 
+    public readonly float RotationY;
+
     public readonly TeleportOptions Options;
 
-    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options)
+    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options) : this(id, offset, options, 0)
+    {
+    }
+
+    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options, float rotationY)
     {
         ID = id;
         Offset = offset;
         Options = options;
+        RotationY = rotationY;
     }
 
     protected override void WriteData(BinaryWriter writer)
@@ -27,6 +34,7 @@ public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionD
         writer.Write(ID);
         writer.WriteVector(Offset);
         writer.Write((byte) Options);
+        writer.Write(RotationY);
     }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
+++ b/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
@@ -8,7 +8,7 @@ public enum TeleportOptions : byte
     ResetFallDamage = 1,
     ResetVelocity = 2,
     WorldSpaceTransform = 4,
-    UseDeltaPlayerRotation = 8,
-    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform | UseDeltaPlayerRotation
+    DeltaRotation = 8,
+    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform | DeltaRotation
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
+++ b/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
@@ -7,7 +7,12 @@ public enum TeleportOptions : byte
     None = 0,
     ResetFallDamage = 1,
     ResetVelocity = 2,
+
+    [Obsolete("Use WorldSpacePosition instead.")]
     WorldSpaceTransform = 4,
-    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform
+
+    WorldSpacePosition = 4,
+    WorldSpaceRotation = 8,
+    All = ResetFallDamage | ResetVelocity | WorldSpacePosition | WorldSpaceRotation
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
+++ b/slocLoader.NWAPI/TriggerActions/Enums/TeleportOptions.cs
@@ -7,12 +7,8 @@ public enum TeleportOptions : byte
     None = 0,
     ResetFallDamage = 1,
     ResetVelocity = 2,
-
-    [Obsolete("Use WorldSpacePosition instead.")]
     WorldSpaceTransform = 4,
-
-    WorldSpacePosition = 4,
-    WorldSpaceRotation = 8,
-    All = ResetFallDamage | ResetVelocity | WorldSpacePosition | WorldSpaceRotation
+    UseDeltaPlayerRotation = 8,
+    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform | UseDeltaPlayerRotation
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -15,7 +15,7 @@ public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler
     protected override void HandlePlayer(ReferenceHub player, TData data, TriggerListener listener)
     {
         if (TryCalculateTransform(player, data, out var pos, out var rotation))
-            player.OverridePosition(pos, data.Options & ~TeleportOptions.DeltaRotation, rotation.eulerAngles.y);
+            player.OverridePosition(pos + Vector3.up, data.Options & ~TeleportOptions.DeltaRotation, rotation.eulerAngles.y);
     }
 
     protected override void HandleItem(ItemPickupBase pickup, TData data, TriggerListener listener)

--- a/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -2,9 +2,8 @@
 using InventorySystem.Items.Pickups;
 using PlayerRoles.Ragdolls;
 using slocLoader.TriggerActions.Data;
-using slocLoader.TriggerActions.Handlers.Abstract;
 
-namespace slocLoader.TriggerActions.Handlers;
+namespace slocLoader.TriggerActions.Handlers.Abstract;
 
 public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler<TData> where TData : BaseTeleportData
 {
@@ -32,7 +31,7 @@ public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler
             TriggerActionHelpers.SetRagdollPositionAndRotation(ragdoll, pos, rotation);
     }
 
-    protected abstract bool TryCalculateTransform(TData data, out Vector3 vector, out Quaternion rotation);
+    protected abstract bool TryCalculateTransform(TData data, out Vector3 position, out Quaternion rotation);
 
     protected void HandleComponent(Component component, TData data)
     {

--- a/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -15,7 +15,7 @@ public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler
     protected override void HandlePlayer(ReferenceHub player, TData data, TriggerListener listener)
     {
         if (TryCalculateTransform(player, data, out var pos, out var rotation))
-            player.OverridePosition(pos + Vector3.up, data.Options & ~TeleportOptions.DeltaRotation, rotation.eulerAngles.y);
+            player.OverridePosition(pos, data.Options & ~TeleportOptions.DeltaRotation, rotation.eulerAngles.y);
     }
 
     protected override void HandleItem(ItemPickupBase pickup, TData data, TriggerListener listener)

--- a/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -2,6 +2,7 @@
 using InventorySystem.Items.Pickups;
 using PlayerRoles.Ragdolls;
 using slocLoader.TriggerActions.Data;
+using slocLoader.TriggerActions.Enums;
 
 namespace slocLoader.TriggerActions.Handlers.Abstract;
 
@@ -14,7 +15,7 @@ public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler
     protected override void HandlePlayer(ReferenceHub player, TData data, TriggerListener listener)
     {
         if (TryCalculateTransform(player, data, out var pos, out var rotation))
-            player.OverridePosition(pos, data.Options, rotation.y);
+            player.OverridePosition(pos, data.Options, data.Options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation) ? data.RotationY : rotation.y);
     }
 
     protected override void HandleItem(ItemPickupBase pickup, TData data, TriggerListener listener)

--- a/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -46,7 +46,7 @@ public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler
             y = data.RotationY;
         }
 
-        var euler = component.transform.rotation.eulerAngles;
+        var euler = component.transform.eulerAngles;
         rotation = Quaternion.Euler(euler.x, data.Options.HasFlagFast(TeleportOptions.DeltaRotation) ? euler.y + data.RotationY : y, euler.z);
         return true;
     }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
@@ -1,7 +1,4 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
@@ -12,39 +9,7 @@ public sealed class MoveRelativeToSelfHandler : TeleportHandlerBase<MoveRelative
 
     public override TriggerActionType ActionType => TriggerActionType.MoveRelativeToSelf;
 
-    private Component _currentComponent;
-
-    protected override bool ValidateData(GameObject interactingObject, MoveRelativeToSelfData data, TriggerListener listener)
-        => !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        _currentComponent = player;
-        base.HandlePlayer(player, data, listener);
-    }
-
-    protected override void HandleItem(ItemPickupBase pickup, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        _currentComponent = pickup;
-        base.HandleItem(pickup, data, listener);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        _currentComponent = toy;
-        base.HandleToy(toy, data, listener);
-    }
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        _currentComponent = ragdoll;
-        base.HandleRagdoll(ragdoll, data, listener);
-    }
-
-    protected override bool TryCalculateTransform(MoveRelativeToSelfData data, out Vector3 position, out Quaternion rotation)
-    {
-        data.ToWorldSpace(_currentComponent.transform, out position, out rotation);
-        return true;
-    }
+    protected override Transform GetReferenceTransform(Component component, MoveRelativeToSelfData data)
+        => component is ReferenceHub hub ? hub.PlayerCameraReference : component.transform;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
@@ -19,7 +19,7 @@ public sealed class MoveRelativeToSelfHandler : UniversalTriggerActionHandler<Mo
     {
         if (!player.TryGetMovementModule(out var module))
             return;
-        var offset = !data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? player.PlayerCameraReference.rotation * data.Position : data.Position;
+        var offset = !data.Options.HasFlagFast(TeleportOptions.WorldSpacePosition) ? player.PlayerCameraReference.rotation * data.Position : data.Position;
         if (data.Options.HasFlagFast(TeleportOptions.ResetFallDamage))
             module.Motor.ResetFallDamageCooldown();
         module.ServerOverridePosition(module.Position + offset, Vector3.zero);

--- a/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
@@ -12,18 +12,11 @@ public sealed class MoveRelativeToSelfHandler : UniversalTriggerActionHandler<Mo
 
     public override TriggerActionType ActionType => TriggerActionType.MoveRelativeToSelf;
 
-    protected override bool ValidateData(GameObject interactingObject, MoveRelativeToSelfData data, TriggerListener listener) =>
-        !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
+    protected override bool ValidateData(GameObject interactingObject, MoveRelativeToSelfData data, TriggerListener listener)
+        => !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
 
     protected override void HandlePlayer(ReferenceHub player, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        if (!player.TryGetMovementModule(out var module))
-            return;
-        var offset = !data.Options.HasFlagFast(TeleportOptions.WorldSpacePosition) ? player.PlayerCameraReference.rotation * data.Position : data.Position;
-        if (data.Options.HasFlagFast(TeleportOptions.ResetFallDamage))
-            module.Motor.ResetFallDamageCooldown();
-        module.ServerOverridePosition(module.Position + offset, Vector3.zero);
-    }
+        => player.OverridePosition(data.Position, data.Options);
 
     protected override void HandleItem(ItemPickupBase pickup, MoveRelativeToSelfData data, TriggerListener listener)
     {
@@ -33,13 +26,18 @@ public sealed class MoveRelativeToSelfHandler : UniversalTriggerActionHandler<Mo
 
     protected override void HandleToy(AdminToyBase toy, MoveRelativeToSelfData data, TriggerListener listener) => HandleComponent(toy, data);
 
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, MoveRelativeToSelfData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.ToWorldSpacePosition(ragdoll.transform));
+    protected override void HandleRagdoll(BasicRagdoll ragdoll, MoveRelativeToSelfData data, TriggerListener listener)
+    {
+        data.ToWorldSpace(ragdoll.transform, out var position, out var rotation);
+        TriggerActionHelpers.SetRagdollPositionAndRotation(ragdoll, position, rotation);
+    }
 
     private static void HandleComponent(Component component, MoveRelativeToSelfData data)
     {
         var t = component.transform;
-        t.position = data.ToWorldSpacePosition(t);
+        data.ToWorldSpace(t, out var position, out var rotation);
+        t.position = position;
+        t.rotation = rotation;
     }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
@@ -9,7 +9,6 @@ public sealed class MoveRelativeToSelfHandler : TeleportHandlerBase<MoveRelative
 
     public override TriggerActionType ActionType => TriggerActionType.MoveRelativeToSelf;
 
-    protected override Transform GetReferenceTransform(Component component, MoveRelativeToSelfData data)
-        => component is ReferenceHub hub ? hub.PlayerCameraReference : component.transform;
+    protected override Transform GetReferenceTransform(Component component, MoveRelativeToSelfData data) => component.transform;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportHandlerBase.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportHandlerBase.cs
@@ -1,0 +1,46 @@
+﻿using AdminToys;
+using InventorySystem.Items.Pickups;
+using PlayerRoles.Ragdolls;
+using slocLoader.TriggerActions.Data;
+using slocLoader.TriggerActions.Handlers.Abstract;
+
+namespace slocLoader.TriggerActions.Handlers;
+
+public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler<TData> where TData : BaseTeleportData
+{
+
+    protected override bool ValidateData(GameObject interactingObject, TData data, TriggerListener listener)
+        => !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
+
+    protected override void HandlePlayer(ReferenceHub player, TData data, TriggerListener listener)
+    {
+        if (TryCalculateTransform(data, out var pos, out var rotation))
+            player.OverridePosition(pos, data.Options, rotation.y);
+    }
+
+    protected override void HandleItem(ItemPickupBase pickup, TData data, TriggerListener listener)
+    {
+        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
+        HandleComponent(pickup, data);
+    }
+
+    protected override void HandleToy(AdminToyBase toy, TData data, TriggerListener listener) => HandleComponent(toy, data);
+
+    protected override void HandleRagdoll(BasicRagdoll ragdoll, TData data, TriggerListener listener)
+    {
+        if (TryCalculateTransform(data, out var pos, out var rotation))
+            TriggerActionHelpers.SetRagdollPositionAndRotation(ragdoll, pos, rotation);
+    }
+
+    protected abstract bool TryCalculateTransform(TData data, out Vector3 vector, out Quaternion rotation);
+
+    protected void HandleComponent(Component component, TData data)
+    {
+        if (!TryCalculateTransform(data, out var pos, out var rotation))
+            return;
+        var t = component.transform;
+        t.position = pos;
+        t.rotation = rotation;
+    }
+
+}

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
@@ -9,11 +9,6 @@ public sealed class TeleportToPositionHandler : TeleportHandlerBase<TeleportToPo
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToPosition;
 
-    protected override bool TryCalculateTransform(TeleportToPositionData data, out Vector3 position, out Quaternion rotation)
-    {
-        position = data.Position;
-        rotation = Quaternion.Euler(0, data.RotationY, 0);
-        return true;
-    }
+    protected override Transform GetReferenceTransform(Component component, TeleportToPositionData data) => component.transform;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
@@ -1,34 +1,19 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToPositionHandler : UniversalTriggerActionHandler<TeleportToPositionData>
+public sealed class TeleportToPositionHandler : TeleportHandlerBase<TeleportToPositionData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToPosition;
 
-    protected override bool ValidateData(GameObject interactingObject, TeleportToPositionData data, TriggerListener listener) =>
-        !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, TeleportToPositionData data, TriggerListener listener) =>
-        player.OverridePosition(data.Position, data.Options);
-
-    protected override void HandleItem(ItemPickupBase pickup, TeleportToPositionData data, TriggerListener listener)
+    protected override bool TryCalculateTransform(TeleportToPositionData data, out Vector3 position, out Quaternion rotation)
     {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
+        position = data.Position;
+        rotation = Quaternion.Euler(0, data.RotationY, 0);
+        return true;
     }
-
-    protected override void HandleToy(AdminToyBase toy, TeleportToPositionData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, TeleportToPositionData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.Position);
-
-    private static void HandleComponent(Component component, TeleportToPositionData data) => component.transform.position = data.Position;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToPositionHandler.cs
@@ -9,6 +9,6 @@ public sealed class TeleportToPositionHandler : TeleportHandlerBase<TeleportToPo
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToPosition;
 
-    protected override Transform GetReferenceTransform(Component component, TeleportToPositionData data) => component.transform;
+    protected override Transform GetReferenceTransform(Component component, TeleportToPositionData data) => null;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
@@ -39,7 +39,7 @@ public sealed class TeleportToRoomHandler : UniversalTriggerActionHandler<Telepo
     private static bool TryCalculatePosition(TeleportToRoomData data, out Vector3 vector)
     {
         var point = new MapPointByName(data.Room, data.Position);
-        if (!data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform))
+        if (!data.Options.HasFlagFast(TeleportOptions.WorldSpacePosition))
             return point.TryGetWorldPose(out vector, out _);
         var transform = point.RoomTransform();
         if (!transform)

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
@@ -1,61 +1,28 @@
-﻿using AdminToys;
-using Axwabo.Helpers.Config;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
+﻿using Axwabo.Helpers.Config;
 using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
-using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToRoomHandler : UniversalTriggerActionHandler<TeleportToRoomData>
+public sealed class TeleportToRoomHandler : TeleportHandlerBase<TeleportToRoomData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToRoom;
 
-    protected override bool ValidateData(GameObject interactingObject, TeleportToRoomData data, TriggerListener listener) =>
-        !string.IsNullOrWhiteSpace(data.Room) && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, TeleportToRoomData data, TriggerListener listener)
+    protected override bool TryCalculateTransform(TeleportToRoomData data, out Vector3 vector, out Quaternion rotation)
     {
-        if (TryCalculatePosition(data, out var pos))
-            player.OverridePosition(pos, data.Options);
-    }
-
-    protected override void HandleItem(ItemPickupBase pickup, TeleportToRoomData data, TriggerListener listener)
-    {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, TeleportToRoomData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, TeleportToRoomData data, TriggerListener listener)
-    {
-        if (TryCalculatePosition(data, out var pos))
-            TriggerActionHelpers.SetRagdollPosition(ragdoll, pos);
-    }
-
-    private static bool TryCalculatePosition(TeleportToRoomData data, out Vector3 vector)
-    {
-        var point = new MapPointByName(data.Room, data.Position);
-        if (!data.Options.HasFlagFast(TeleportOptions.WorldSpacePosition))
-            return point.TryGetWorldPose(out vector, out _);
-        var transform = point.RoomTransform();
+        var transform = ConfigHelper.GetRoomByRoomName(data.Room).SafeGetTransform();
         if (!transform)
         {
             vector = Vector3.zero;
+            rotation = Quaternion.identity;
             return false;
         }
 
-        vector = transform.position + data.Position;
+        vector = data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? transform.position + data.Position : transform.TransformPoint(data.Position);
+        var quaternion = Quaternion.Euler(0, data.RotationY, 0);
+        rotation = data.Options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation) ? quaternion : transform.rotation * quaternion;
         return true;
-    }
-
-    private static void HandleComponent(Component component, TeleportToRoomData data)
-    {
-        if (TryCalculatePosition(data, out var pos))
-            component.transform.position = pos;
     }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
@@ -10,20 +10,7 @@ public sealed class TeleportToRoomHandler : TeleportHandlerBase<TeleportToRoomDa
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToRoom;
 
-    protected override bool TryCalculateTransform(TeleportToRoomData data, out Vector3 position, out Quaternion rotation)
-    {
-        var transform = ConfigHelper.GetRoomByRoomName(data.Room).SafeGetTransform();
-        if (!transform)
-        {
-            position = Vector3.zero;
-            rotation = Quaternion.identity;
-            return false;
-        }
-
-        position = data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? transform.position + data.Position : transform.TransformPoint(data.Position);
-        var quaternion = Quaternion.Euler(0, data.RotationY, 0);
-        rotation = data.Options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation) ? quaternion : transform.rotation * quaternion;
-        return true;
-    }
+    protected override Transform GetReferenceTransform(Component component, TeleportToRoomData data)
+        => ConfigHelper.GetRoomByRoomName(data.Room).SafeGetTransform();
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToRoomHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Axwabo.Helpers.Config;
 using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
+using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
@@ -9,17 +10,17 @@ public sealed class TeleportToRoomHandler : TeleportHandlerBase<TeleportToRoomDa
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToRoom;
 
-    protected override bool TryCalculateTransform(TeleportToRoomData data, out Vector3 vector, out Quaternion rotation)
+    protected override bool TryCalculateTransform(TeleportToRoomData data, out Vector3 position, out Quaternion rotation)
     {
         var transform = ConfigHelper.GetRoomByRoomName(data.Room).SafeGetTransform();
         if (!transform)
         {
-            vector = Vector3.zero;
+            position = Vector3.zero;
             rotation = Quaternion.identity;
             return false;
         }
 
-        vector = data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? transform.position + data.Position : transform.TransformPoint(data.Position);
+        position = data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? transform.position + data.Position : transform.TransformPoint(data.Position);
         var quaternion = Quaternion.Euler(0, data.RotationY, 0);
         rotation = data.Options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation) ? quaternion : transform.rotation * quaternion;
         return true;

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
@@ -1,35 +1,21 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToSpawnedObjectHandler : UniversalTriggerActionHandler<RuntimeTeleportToSpawnedObjectData>
+public sealed class TeleportToSpawnedObjectHandler : TeleportHandlerBase<RuntimeTeleportToSpawnedObjectData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToSpawnedObject;
 
-    protected override bool ValidateData(GameObject interactingObject, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        data.Target != null && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
+    protected override bool ValidateData(GameObject interactingObject, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener)
+        => data.Target != null && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
 
-    protected override void HandlePlayer(ReferenceHub player, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        player.OverridePosition(data.ToWorldSpacePosition(data.Target.transform), data.Options);
-
-    protected override void HandleItem(ItemPickupBase pickup, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener)
+    protected override bool TryCalculateTransform(RuntimeTeleportToSpawnedObjectData data, out Vector3 position, out Quaternion rotation)
     {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
+        data.ToWorldSpace(data.Target.transform, out position, out rotation);
+        return true;
     }
-
-    protected override void HandleToy(AdminToyBase toy, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.ToWorldSpacePosition(data.Target.transform));
-
-    private static void HandleComponent(Component component, RuntimeTeleportToSpawnedObjectData data) =>
-        component.transform.position = data.ToWorldSpacePosition(data.Target.transform);
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
@@ -12,10 +12,6 @@ public sealed class TeleportToSpawnedObjectHandler : TeleportHandlerBase<Runtime
     protected override bool ValidateData(GameObject interactingObject, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener)
         => data.Target != null && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
 
-    protected override bool TryCalculateTransform(RuntimeTeleportToSpawnedObjectData data, out Vector3 position, out Quaternion rotation)
-    {
-        data.ToWorldSpace(data.Target.transform, out position, out rotation);
-        return true;
-    }
+    protected override Transform GetReferenceTransform(Component component, RuntimeTeleportToSpawnedObjectData data) => data.Target.transform;
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
@@ -63,7 +63,7 @@ public static class TriggerActionHelpers
             module.Motor.ResetFallDamageCooldown();
         var finalRotation = options.HasFlagFast(TeleportOptions.DeltaRotation)
             ? rotation
-            : module.MouseLook.CurrentHorizontal - rotation;
+            : rotation - module.MouseLook.CurrentHorizontal;
         module.ServerOverridePosition(position, new Vector3(0, finalRotation, 0));
     }
 

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
@@ -53,7 +53,7 @@ public static class TriggerActionHelpers
     }
 
     public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options = TeleportOptions.ResetFallDamage)
-        => hub.OverridePosition(position, options & ~TeleportOptions.WorldSpaceRotation, 0);
+        => hub.OverridePosition(position, options | TeleportOptions.UseDeltaPlayerRotation, 0);
 
     public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options, float rotation)
     {
@@ -61,9 +61,9 @@ public static class TriggerActionHelpers
             return;
         if (options.HasFlagFast(TeleportOptions.ResetFallDamage))
             module.Motor.ResetFallDamageCooldown();
-        var finalRotation = options.HasFlagFast(TeleportOptions.WorldSpaceRotation)
-            ? module.MouseLook.CurrentHorizontal - rotation
-            : rotation;
+        var finalRotation = options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation)
+            ? rotation
+            : module.MouseLook.CurrentHorizontal - rotation;
         module.ServerOverridePosition(position, new Vector3(0, finalRotation, 0));
     }
 

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
@@ -53,7 +53,7 @@ public static class TriggerActionHelpers
     }
 
     public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options = TeleportOptions.ResetFallDamage)
-        => hub.OverridePosition(position, options | TeleportOptions.UseDeltaPlayerRotation, 0);
+        => hub.OverridePosition(position, options | TeleportOptions.DeltaRotation, 0);
 
     public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options, float rotation)
     {
@@ -61,7 +61,7 @@ public static class TriggerActionHelpers
             return;
         if (options.HasFlagFast(TeleportOptions.ResetFallDamage))
             module.Motor.ResetFallDamageCooldown();
-        var finalRotation = options.HasFlagFast(TeleportOptions.UseDeltaPlayerRotation)
+        var finalRotation = options.HasFlagFast(TeleportOptions.DeltaRotation)
             ? rotation
             : module.MouseLook.CurrentHorizontal - rotation;
         module.ServerOverridePosition(position, new Vector3(0, finalRotation, 0));

--- a/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
+++ b/slocLoader.NWAPI/TriggerActions/Handlers/TriggerActionHelpers.cs
@@ -33,6 +33,7 @@ public static class TriggerActionHelpers
         {
             case PickupStandardPhysics physics:
                 physics.Rb.velocity = Vector3.zero;
+                physics.Rb.angularVelocity = Vector3.zero;
                 break;
             case Scp018Physics scp018:
                 scp018._lastVelocity = Vector3.zero;
@@ -61,10 +62,10 @@ public static class TriggerActionHelpers
             return;
         if (options.HasFlagFast(TeleportOptions.ResetFallDamage))
             module.Motor.ResetFallDamageCooldown();
-        var finalRotation = options.HasFlagFast(TeleportOptions.DeltaRotation)
+        var delta = options.HasFlagFast(TeleportOptions.DeltaRotation)
             ? rotation
             : rotation - module.MouseLook.CurrentHorizontal;
-        module.ServerOverridePosition(position, new Vector3(0, finalRotation, 0));
+        module.ServerOverridePosition(position, new Vector3(0, delta, 0));
     }
 
 }

--- a/slocLoader.NWAPI/TriggerActions/Readers/Ver5ActionDataReader.cs
+++ b/slocLoader.NWAPI/TriggerActions/Readers/Ver5ActionDataReader.cs
@@ -1,0 +1,62 @@
+﻿using slocLoader.TriggerActions.Data;
+using slocLoader.TriggerActions.Enums;
+
+namespace slocLoader.TriggerActions.Readers;
+
+public sealed class Ver5ActionDataReader : ITriggerActionDataReader
+{
+
+    public BaseTriggerActionData Read(BinaryReader reader)
+    {
+        ActionManager.ReadTypes(reader, out var actionType, out var targetType, out var eventType);
+        BaseTriggerActionData data = actionType switch
+        {
+            TriggerActionType.TeleportToPosition => ReadTpToPos(reader),
+            TriggerActionType.MoveRelativeToSelf => ReadMoveRelative(reader),
+            TriggerActionType.TeleportToRoom => ReadTpToRoom(reader),
+            TriggerActionType.KillPlayer => Ver4ActionDataReader.ReadKillPlayer(reader),
+            TriggerActionType.TeleportToSpawnedObject => ReadTpToSpawnedObject(reader),
+            TriggerActionType.TeleporterImmunity => Ver4ActionDataReader.ReadTeleporterImmunity(reader),
+            _ => null
+        };
+        if (data is null)
+            return null;
+        data.SelectedTargets = targetType;
+        data.SelectedEvents = eventType;
+        return data;
+    }
+
+    public static TeleportToPositionData ReadTpToPos(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        return new TeleportToPositionData(position) {Options = options, RotationY = rotation};
+    }
+
+    public static MoveRelativeToSelfData ReadMoveRelative(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        return new MoveRelativeToSelfData(position) {Options = options, RotationY = rotation};
+    }
+
+    public static TeleportToRoomData ReadTpToRoom(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        var name = reader.ReadString();
+        return new TeleportToRoomData(name, position) {Options = options, RotationY = rotation};
+    }
+
+    public static SerializableTeleportToSpawnedObjectData ReadTpToSpawnedObject(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var offset, out var options, out var rotation);
+        var virtualInstanceId = reader.ReadInt32();
+        return new SerializableTeleportToSpawnedObjectData(virtualInstanceId, offset, options, rotation);
+    }
+
+    public static void ReadTeleportData(BinaryReader reader, out Vector3 position, out TeleportOptions options, out float rotation)
+    {
+        position = reader.ReadVector();
+        options = (TeleportOptions) reader.ReadByte();
+        rotation = reader.ReadSingle();
+    }
+
+}

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -116,6 +116,7 @@
         <Compile Include="Readers\Ver3Reader.cs"/>
         <Compile Include="Readers\Ver4Reader.cs"/>
         <Compile Include="Readers\Ver5Reader.cs"/>
+        <Compile Include="SendSpawnMessagePatch.cs"/>
         <Compile Include="SetPrimitiveTypePatch.cs"/>
         <Compile Include="slocAttributes.cs"/>
         <Compile Include="slocConfig.cs"/>

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -148,6 +148,7 @@
         <Compile Include="TriggerActions\Handlers\TeleporterImmunityHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToPositionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToRoomHandler.cs"/>
+        <Compile Include="TriggerActions\Handlers\TeleportHandlerBase.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToSpawnedObjectHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TriggerActionHelpers.cs"/>
         <Compile Include="TriggerActions\Readers\ITriggerActionDataReader.cs"/>

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -140,6 +140,7 @@
         <Compile Include="TriggerActions\Handlers\Abstract\PickupActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\PlayerActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\RagdollActionHandler.cs"/>
+        <Compile Include="TriggerActions\Handlers\Abstract\TeleportHandlerBase.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\ToyActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\UniversalTriggerActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\ITriggerActionHandler.cs"/>
@@ -148,7 +149,6 @@
         <Compile Include="TriggerActions\Handlers\TeleporterImmunityHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToPositionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToRoomHandler.cs"/>
-        <Compile Include="TriggerActions\Handlers\TeleportHandlerBase.cs"/>
         <Compile Include="TriggerActions\Handlers\TeleportToSpawnedObjectHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\TriggerActionHelpers.cs"/>
         <Compile Include="TriggerActions\Readers\ITriggerActionDataReader.cs"/>

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -97,6 +97,7 @@
         <Compile Include="Commands\ReloadCommand.cs"/>
         <Compile Include="Commands\RotationCommand.cs"/>
         <Compile Include="Commands\SpawnCommand.cs"/>
+        <Compile Include="Commands\StructureCommand.cs"/>
         <Compile Include="GlobalUsings.cs"/>
         <Compile Include="InstanceDictionary.cs"/>
         <Compile Include="Objects\EmptyObject.cs"/>

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -152,6 +152,7 @@
         <Compile Include="TriggerActions\Handlers\TriggerActionHelpers.cs"/>
         <Compile Include="TriggerActions\Readers\ITriggerActionDataReader.cs"/>
         <Compile Include="TriggerActions\Readers\Ver4ActionDataReader.cs"/>
+        <Compile Include="TriggerActions\Readers\Ver5ActionDataReader.cs"/>
         <Compile Include="TriggerActions\TeleporterImmunityStorage.cs"/>
         <Compile Include="TriggerActions\TriggerListener.cs"/>
         <Compile Include="TriggerActions\TriggerListenerInvoker.cs"/>

--- a/slocLoader.NWAPI/slocLoader.NWAPI.csproj
+++ b/slocLoader.NWAPI/slocLoader.NWAPI.csproj
@@ -107,6 +107,7 @@
         <Compile Include="Objects\slocTransform.cs"/>
         <Compile Include="ObjectCreation\ObjectsSource.cs"/>
         <Compile Include="ObjectCreation\CreateOptions.cs"/>
+        <Compile Include="Objects\StructureObject.cs"/>
         <Compile Include="Properties\AssemblyInfo.cs"/>
         <Compile Include="Readers\IObjectReader.cs"/>
         <Compile Include="Readers\slocHeader.cs"/>
@@ -114,6 +115,7 @@
         <Compile Include="Readers\Ver2Reader.cs"/>
         <Compile Include="Readers\Ver3Reader.cs"/>
         <Compile Include="Readers\Ver4Reader.cs"/>
+        <Compile Include="Readers\Ver5Reader.cs"/>
         <Compile Include="SetPrimitiveTypePatch.cs"/>
         <Compile Include="slocAttributes.cs"/>
         <Compile Include="slocConfig.cs"/>

--- a/slocLoader.NWAPI/slocPlugin.cs
+++ b/slocLoader.NWAPI/slocPlugin.cs
@@ -16,7 +16,7 @@ public sealed class slocPlugin
     [PluginConfig]
     public slocConfig Config = new();
 
-    [PluginEntryPoint("slocLoader", "4.2.4", "A plugin that loads sloc files.", "Axwabo")]
+    [PluginEntryPoint("slocLoader", "5.0.0", "A plugin that loads sloc files.", "Axwabo")]
     public void OnEnabled()
     {
         Instance = this;

--- a/slocLoader/API.Create.cs
+++ b/slocLoader/API.Create.cs
@@ -222,7 +222,8 @@ public static partial class API
                 kvp.Key.AddTriggerAction(new RuntimeTeleportToSpawnedObjectData(target, data.Offset)
                 {
                     SelectedTargets = data.SelectedTargets,
-                    Options = data.Options
+                    Options = data.Options,
+                    RotationY = data.RotationY
                 }, handler);
         }
     }

--- a/slocLoader/API.Create.cs
+++ b/slocLoader/API.Create.cs
@@ -1,4 +1,5 @@
-﻿using Mirror;
+﻿using MapGeneration.Distributors;
+using Mirror;
 using slocLoader.ObjectCreation;
 using slocLoader.Objects;
 using slocLoader.TriggerActions;
@@ -63,10 +64,12 @@ public static partial class API
     {
         if (!StructurePrefabIds.TryGetValue(structure.Structure, out var id) || !NetworkClient.prefabs.TryGetValue(id, out var prefab))
             return null;
-        var gameObject = Object.Instantiate(prefab);
-        gameObject.SetAbsoluteTransformFrom(parent);
-        gameObject.SetLocalTransform(structure.Transform);
-        return gameObject;
+        var o = Object.Instantiate(prefab);
+        o.SetAbsoluteTransformFrom(parent);
+        o.SetLocalTransform(structure.Transform);
+        if (structure.RemoveDefaultLoot && o.TryGetComponent(out Locker locker))
+            locker.Loot = Array.Empty<LockerLoot>();
+        return o;
     }
 
     private static GameObject CreatePrimitive(GameObject parent, PrimitiveObject primitive)

--- a/slocLoader/API.Create.cs
+++ b/slocLoader/API.Create.cs
@@ -18,21 +18,58 @@ public static partial class API
             or ObjectType.Cylinder
             or ObjectType.Plane
             or ObjectType.Capsule
-            or ObjectType.Quad => new PrimitiveObject(0, type),
-        ObjectType.Light => new LightObject(0),
-        ObjectType.Empty => new EmptyObject(0),
+            or ObjectType.Quad => new PrimitiveObject(type),
+        ObjectType.Light => new LightObject(),
+        ObjectType.Empty => new EmptyObject(),
+        ObjectType.Structure => new StructureObject(StructureObject.StructureType.None),
         _ => null
     };
 
     public static GameObject CreateObject(this slocGameObject obj, GameObject parent = null, bool throwOnError = true) => obj switch
     {
-        PrimitiveObject primitive => CreatePrimitive(parent, primitive, obj.Transform),
-        LightObject light => CreateLight(parent, obj.Transform, light),
+        StructureObject structure => CreateStructure(parent, structure),
+        PrimitiveObject primitive => CreatePrimitive(parent, primitive),
+        LightObject light => CreateLight(parent, light),
         EmptyObject => CreateEmpty(parent, obj.Transform),
         _ => throwOnError ? throw new IndexOutOfRangeException($"Unknown object type {obj.Type}") : null
     };
 
-    private static GameObject CreatePrimitive(GameObject parent, PrimitiveObject primitive, slocTransform transform)
+    public static readonly Dictionary<StructureObject.StructureType, uint> StructurePrefabIds = new()
+    {
+        {StructureObject.StructureType.Adrenaline, 2525847434},
+        {StructureObject.StructureType.BinaryTarget, 3613149668},
+        {StructureObject.StructureType.DboyTarget, 858699872},
+        {StructureObject.StructureType.EzBreakableDoor, 1883254029},
+        {StructureObject.StructureType.Generator, 2724603877},
+        {StructureObject.StructureType.HczBreakableDoor, 2295511789},
+        {StructureObject.StructureType.LargeGunLocker, 2830750618},
+        {StructureObject.StructureType.LczBreakableDoor, 3038351124},
+        {StructureObject.StructureType.Medkit, 4040822781},
+        {StructureObject.StructureType.MiscellaneousLocker, 1964083310},
+        {StructureObject.StructureType.RifleRack, 3352879624},
+        {StructureObject.StructureType.Scp018Pedestal, 2286635216},
+        {StructureObject.StructureType.Scp207Pedestal, 664776131},
+        {StructureObject.StructureType.Scp244Pedestal, 3724306703},
+        {StructureObject.StructureType.Scp268Pedestal, 3849573771},
+        {StructureObject.StructureType.Scp500Pedestal, 373821065},
+        {StructureObject.StructureType.Scp1576Pedestal, 3372339835},
+        {StructureObject.StructureType.Scp1853Pedestal, 3962534659},
+        {StructureObject.StructureType.Scp2176Pedestal, 3578915554},
+        {StructureObject.StructureType.SportTarget, 1704345398},
+        {StructureObject.StructureType.Workstation, 1783091262}
+    };
+
+    private static GameObject CreateStructure(GameObject parent, StructureObject structure)
+    {
+        if (!StructurePrefabIds.TryGetValue(structure.Structure, out var id) || !NetworkClient.prefabs.TryGetValue(id, out var prefab))
+            return null;
+        var gameObject = Object.Instantiate(prefab);
+        gameObject.SetAbsoluteTransformFrom(parent);
+        gameObject.SetLocalTransform(structure.Transform);
+        return gameObject;
+    }
+
+    private static GameObject CreatePrimitive(GameObject parent, PrimitiveObject primitive)
     {
         if (PrimitivePrefab == null)
             throw new InvalidOperationException("Primitive prefab is not set! Make sure to spawn objects after the prefabs have been loaded.");
@@ -52,24 +89,24 @@ public static partial class API
         toy.PrimitiveType = primitiveType;
         toy.MovementSmoothing = primitive.MovementSmoothing;
         toy.SetAbsoluteTransformFrom(parent);
-        toy.SetLocalTransform(transform);
-        toy.Scale = AdminToyPatch.GetScale(transform.Scale, sloc.HasColliderOnClient);
+        toy.SetLocalTransform(primitive.Transform);
+        toy.Scale = AdminToyPatch.GetScale(primitive.Transform.Scale, sloc.HasColliderOnClient);
         toy.MaterialColor = primitive.MaterialColor;
         return o;
     }
 
-    private static GameObject CreateLight(GameObject parent, slocTransform transform, LightObject light)
+    private static GameObject CreateLight(GameObject parent, LightObject light)
     {
         if (LightPrefab == null)
             throw new InvalidOperationException("Light prefab is not set! Make sure to spawn objects after the prefabs have been loaded.");
         var toy = Object.Instantiate(LightPrefab);
         toy.SetAbsoluteTransformFrom(parent);
-        toy.SetLocalTransform(transform);
+        toy.SetLocalTransform(light.Transform);
         toy.LightColor = light.LightColor;
         toy.LightShadows = light.Shadows;
         toy.LightRange = light.Range;
         toy.LightIntensity = light.Intensity;
-        toy.Scale = transform.Scale;
+        toy.Scale = light.Transform.Scale;
         toy.MovementSmoothing = light.MovementSmoothing;
         return toy.gameObject;
     }

--- a/slocLoader/API.Create.cs
+++ b/slocLoader/API.Create.cs
@@ -67,6 +67,7 @@ public static partial class API
         var o = Object.Instantiate(prefab);
         o.SetAbsoluteTransformFrom(parent);
         o.SetLocalTransform(structure.Transform);
+        o.AddComponent<slocObjectData>();
         if (structure.RemoveDefaultLoot && o.TryGetComponent(out Locker locker))
             locker.Loot = Array.Empty<LockerLoot>();
         return o;

--- a/slocLoader/API.Read.cs
+++ b/slocLoader/API.Read.cs
@@ -8,14 +8,15 @@ public static partial class API
 
     #region Reader Declarations
 
-    public static readonly IObjectReader DefaultReader = new Ver4Reader();
+    public static readonly IObjectReader DefaultReader = new Ver5Reader();
 
     private static readonly Dictionary<ushort, IObjectReader> VersionReaders = new()
     {
         {1, new Ver1Reader()},
         {2, new Ver2Reader()},
         {3, new Ver3Reader()},
-        {4, new Ver4Reader()}
+        {4, new Ver4Reader()},
+        {5, DefaultReader}
     };
 
     public static bool TryGetReader(ushort version, out IObjectReader reader) => VersionReaders.TryGetValue(version, out reader);

--- a/slocLoader/API.Spawn.cs
+++ b/slocLoader/API.Spawn.cs
@@ -37,7 +37,7 @@ public static partial class API
         if (o == null)
         {
             if (throwOnError)
-                throw new ArgumentOutOfRangeException(nameof(obj.Type), obj.Type, "Unknown object type");
+                throw new ArgumentOutOfRangeException(nameof(obj), $"Failed to create object of type {obj.Type}");
             return null;
         }
 

--- a/slocLoader/API.cs
+++ b/slocLoader/API.cs
@@ -13,7 +13,7 @@ namespace slocLoader;
 public static partial class API
 {
 
-    public const ushort slocVersion = 4;
+    public const ushort slocVersion = 5;
 
     public const float ColorDivisionMultiplier = 1f / 255f;
 

--- a/slocLoader/Commands/ReloadCommand.cs
+++ b/slocLoader/Commands/ReloadCommand.cs
@@ -4,6 +4,7 @@ using slocLoader.AutoObjectLoader;
 namespace slocLoader.Commands;
 
 [CommandHandler(typeof(GameConsoleCommandHandler))]
+[CommandHandler(typeof(RemoteAdminCommandHandler))]
 public sealed class ReloadCommand : ICommand
 {
 
@@ -13,6 +14,12 @@ public sealed class ReloadCommand : ICommand
 
     public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
     {
+        if (!sender.CheckPermission(PlayerPermissions.ServerConfigs))
+        {
+            response = "You don't have permission to do that (ServerConfigs)!";
+            return false;
+        }
+
         AutomaticObjectLoader.LoadObjects();
         response = "Reload complete.";
         return true;

--- a/slocLoader/Commands/StructureCommand.cs
+++ b/slocLoader/Commands/StructureCommand.cs
@@ -1,0 +1,60 @@
+﻿using CommandSystem;
+using Exiled.Permissions.Extensions;
+using Mirror;
+using slocLoader.Objects;
+
+namespace slocLoader.Commands;
+
+[CommandHandler(typeof(RemoteAdminCommandHandler))]
+public sealed class StructureCommand : ICommand, IUsageProvider
+{
+
+    public string[] Usage { get; } = {"type"};
+    public string Command => "sl_structure";
+    public string[] Aliases => Array.Empty<string>();
+    public string Description => "Spawns the specified structure type.";
+
+    public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
+    {
+        var p = Player.Get(sender);
+        if (p == null)
+        {
+            response = "You must be a player to execute this command!";
+            return false;
+        }
+
+        if (!p.CheckPermission("sloc.spawn"))
+        {
+            response = "You don't have permission to do that (sloc.spawn)!";
+            return false;
+        }
+
+        if (arguments.Count < 1)
+        {
+            response = "Usage: sl_structure <structure type>";
+            return false;
+        }
+
+        if (!arguments.ParseEnumIgnoreCase(out StructureObject.StructureType type))
+        {
+            response = "Unknown structure type.\nValid types: " + string.Join(", ", Enum.GetNames(typeof(StructureObject.StructureType)));
+            return false;
+        }
+
+        var position = PositionCommand.Defined.TryGetValue(p.UserId, out var pos) ? pos : p.Position;
+        var rotation = RotationCommand.Defined.TryGetValue(p.UserId, out var rot)
+            ? rot
+            : new Quaternion(0, p.ReferenceHub.PlayerCameraReference.rotation.y, 0, 1);
+        var go = new StructureObject(type)
+        {
+            Transform =
+            {
+                Position = position,
+                Rotation = rotation
+            }
+        }.SpawnObject();
+        response = $"Spawned {type} with NetID: {go.GetComponent<NetworkIdentity>().netId}";
+        return true;
+    }
+
+}

--- a/slocLoader/Objects/ObjectType.cs
+++ b/slocLoader/Objects/ObjectType.cs
@@ -11,6 +11,7 @@ public enum ObjectType : byte
     Cylinder = 5,
     Plane = 6,
     Quad = 7,
-    Empty = 8
+    Empty = 8,
+    Structure = 9
 
 }

--- a/slocLoader/Objects/StructureObject.cs
+++ b/slocLoader/Objects/StructureObject.cs
@@ -1,0 +1,52 @@
+﻿using slocLoader.Readers;
+
+namespace slocLoader.Objects;
+
+public sealed class StructureObject : slocGameObject
+{
+
+    public StructureObject(StructureType structureType) : this(0, structureType)
+    {
+    }
+
+    public StructureObject(int instanceId, StructureType structureType) : base(instanceId)
+    {
+        Type = ObjectType.Structure;
+        Structure = structureType;
+    }
+
+    public StructureType Structure { get; set; }
+
+    public override bool IsValid => Structure != StructureType.None;
+
+    protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+
+    public enum StructureType : byte
+    {
+
+        None = 0,
+        Adrenaline = 1,
+        BinaryTarget = 2,
+        DboyTarget = 3,
+        EzBreakableDoor = 4,
+        Generator = 5,
+        HczBreakableDoor = 6,
+        LczBreakableDoor = 7,
+        LargeGunLocker = 8,
+        MiscellaneousLocker = 9,
+        Medkit = 10,
+        RifleRack = 11,
+        Scp018Pedestal = 12,
+        Scp207Pedestal = 13,
+        Scp244Pedestal = 14,
+        Scp268Pedestal = 15,
+        Scp500Pedestal = 16,
+        Scp1576Pedestal = 17,
+        Scp1853Pedestal = 18,
+        Scp2176Pedestal = 19,
+        SportTarget = 20,
+        Workstation = 21
+
+    }
+
+}

--- a/slocLoader/Objects/StructureObject.cs
+++ b/slocLoader/Objects/StructureObject.cs
@@ -5,6 +5,8 @@ namespace slocLoader.Objects;
 public sealed class StructureObject : slocGameObject
 {
 
+    public const int RemoveDefaultLootBit = 0b1000_0000;
+
     public StructureObject(StructureType structureType) : this(0, structureType)
     {
     }
@@ -17,9 +19,12 @@ public sealed class StructureObject : slocGameObject
 
     public StructureType Structure { get; set; }
 
+    public bool RemoveDefaultLoot { get; set; }
+
     public override bool IsValid => Structure != StructureType.None;
 
-    protected override void WriteData(BinaryWriter writer, slocHeader header) => writer.Write((byte) Structure);
+    protected override void WriteData(BinaryWriter writer, slocHeader header)
+        => writer.Write((byte) ((int) Structure | (RemoveDefaultLoot ? RemoveDefaultLootBit : 0)));
 
     public enum StructureType : byte
     {

--- a/slocLoader/Properties/AssemblyInfo.cs
+++ b/slocLoader/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.4.0")]
-[assembly: AssemblyFileVersion("4.2.4.0")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]

--- a/slocLoader/Readers/Ver5Reader.cs
+++ b/slocLoader/Readers/Ver5Reader.cs
@@ -1,0 +1,44 @@
+﻿using slocLoader.Objects;
+
+namespace slocLoader.Readers
+{
+
+    public sealed class Ver5Reader : IObjectReader
+    {
+
+        public slocHeader ReadHeader(BinaryReader stream) => Ver3Reader.ReadHeaderStatic(stream, 5);
+
+        public slocGameObject Read(BinaryReader stream, slocHeader header)
+        {
+            var objectType = (ObjectType) stream.ReadByte();
+            return objectType switch
+            {
+                ObjectType.Structure => ReadStructure(stream),
+                ObjectType.Cube
+                    or ObjectType.Sphere
+                    or ObjectType.Cylinder
+                    or ObjectType.Plane
+                    or ObjectType.Capsule
+                    or ObjectType.Quad => Ver4Reader.ReadPrimitive(stream, objectType, header),
+                ObjectType.Light => Ver3Reader.ReadLight(stream, header),
+                ObjectType.Empty => Ver2Reader.ReadEmpty(stream),
+                _ => null
+            };
+        }
+
+        public static StructureObject ReadStructure(BinaryReader stream)
+        {
+            var instanceId = stream.ReadInt32();
+            var parentId = stream.ReadInt32();
+            var transform = stream.ReadTransform();
+            var structureType = (StructureObject.StructureType) stream.ReadByte();
+            return new StructureObject(instanceId, structureType)
+            {
+                ParentId = parentId,
+                Transform = transform
+            };
+        }
+
+    }
+
+}

--- a/slocLoader/Readers/Ver5Reader.cs
+++ b/slocLoader/Readers/Ver5Reader.cs
@@ -31,11 +31,12 @@ namespace slocLoader.Readers
             var instanceId = stream.ReadInt32();
             var parentId = stream.ReadInt32();
             var transform = stream.ReadTransform();
-            var structureType = (StructureObject.StructureType) stream.ReadByte();
-            return new StructureObject(instanceId, structureType)
+            var typeData = stream.ReadByte();
+            return new StructureObject(instanceId, (StructureObject.StructureType) (typeData & ~StructureObject.RemoveDefaultLootBit))
             {
                 ParentId = parentId,
-                Transform = transform
+                Transform = transform,
+                RemoveDefaultLoot = (typeData & StructureObject.RemoveDefaultLootBit) != 0
             };
         }
 

--- a/slocLoader/SendSpawnMessagePatch.cs
+++ b/slocLoader/SendSpawnMessagePatch.cs
@@ -1,0 +1,45 @@
+﻿using HarmonyLib;
+using Mirror;
+using static Axwabo.Helpers.Harmony.InstructionHelper;
+
+namespace slocLoader;
+
+[HarmonyPatch(typeof(NetworkServer), nameof(NetworkServer.SendSpawnMessage))]
+public static class SendSpawnMessagePatch
+{
+
+    public delegate void SpawnDataModifier(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message);
+
+    public static readonly List<SpawnDataModifier> SpawnDataModifiers = new List<SpawnDataModifier> {SetGlobalTransformForSlocObject};
+
+    public static void ModifySpawnMessage(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message)
+    {
+        foreach (var modifier in SpawnDataModifiers)
+            modifier(identity, connection, ref message);
+    }
+
+    private static void SetGlobalTransformForSlocObject(NetworkIdentity identity, NetworkConnection connection, ref SpawnMessage message)
+    {
+        if (!identity.TryGetComponent(out slocObjectData _))
+            return;
+        var transform = identity.transform;
+        message.position = transform.position;
+        message.rotation = transform.rotation;
+        message.scale = transform.lossyScale;
+    }
+
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var list = new List<CodeInstruction>(instructions);
+        var index = list.FindCall(nameof(NetworkConnection.Send)) - 3;
+        list.InsertRange(index, new[]
+        {
+            Ldarg(0),
+            Ldarg(1),
+            Ldloca(4),
+            Call(ModifySpawnMessage)
+        });
+        return list;
+    }
+
+}

--- a/slocLoader/TriggerActions/ActionManager.cs
+++ b/slocLoader/TriggerActions/ActionManager.cs
@@ -10,11 +10,12 @@ public static class ActionManager
 
     public const ushort MinVersion = 4;
 
-    private static readonly ITriggerActionDataReader DefaultReader = new Ver4ActionDataReader();
+    private static readonly ITriggerActionDataReader DefaultReader = new Ver5ActionDataReader();
 
     private static readonly Dictionary<ushort, ITriggerActionDataReader> Readers = new()
     {
-        {4, new Ver4ActionDataReader()}
+        {4, new Ver4ActionDataReader()},
+        {5, DefaultReader}
     };
 
     public static readonly ICollection<TargetType> TargetTypeValues = new List<TargetType>
@@ -36,7 +37,8 @@ public static class ActionManager
     {
         TeleportOptions.ResetFallDamage,
         TeleportOptions.ResetVelocity,
-        TeleportOptions.WorldSpaceTransform
+        TeleportOptions.WorldSpaceTransform,
+        TeleportOptions.DeltaRotation
     }.AsReadOnly();
 
     private static readonly ITriggerActionHandler[] ActionHandlers =
@@ -80,8 +82,7 @@ public static class ActionManager
                 actions.Add(action);
         }
 
-        var array = actions.ToArray();
-        return array;
+        return actions.ToArray();
     }
 
     public static void ReadTypes(BinaryReader reader, out TriggerActionType actionType, out TargetType targetType, out TriggerEventType eventType)
@@ -117,7 +118,7 @@ public static class ActionManager
 
     public static bool HasFlagFast(this TeleportOptions options, TeleportOptions flag) => (options & flag) == flag;
 
-    public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.None || type.HasFlagFast(isType);
+    public static bool Is(this TeleportOptions type, TeleportOptions isType) => type is TeleportOptions.All || type.HasFlagFast(isType);
 
     public static bool ContainsAnyOf(this TargetType type, TargetType multiple) => type is TargetType.All || TargetTypeValues.Any(targetType => type.HasFlagFast(targetType) && multiple.HasFlagFast(targetType));
 

--- a/slocLoader/TriggerActions/Data/BaseTeleportData.cs
+++ b/slocLoader/TriggerActions/Data/BaseTeleportData.cs
@@ -9,12 +9,16 @@ public abstract class BaseTeleportData : BaseTriggerActionData
     public Vector3 Position { get; set; }
 
     [field: SerializeField]
-    public TeleportOptions Options { get; set; }
+    public TeleportOptions Options { get; set; } = TeleportOptions.ResetFallDamage | TeleportOptions.DeltaRotation;
+
+    [field: SerializeField]
+    public float RotationY { get; set; }
 
     protected sealed override void WriteData(BinaryWriter writer)
     {
         writer.WriteVector(Position);
         writer.Write((byte) Options);
+        writer.Write(RotationY);
         WriteAdditionalData(writer);
     }
 
@@ -26,5 +30,13 @@ public abstract class BaseTeleportData : BaseTriggerActionData
         Options.HasFlag(TeleportOptions.WorldSpaceTransform)
             ? reference.position + Position
             : reference.TransformPoint(Position);
+
+    public void ToWorldSpace(Transform reference, out Vector3 position, out float rotation)
+    {
+        position = ToWorldSpacePosition(reference);
+        rotation = Options.HasFlag(TeleportOptions.WorldSpaceTransform)
+            ? RotationY
+            : reference.rotation.eulerAngles.y + RotationY;
+    }
 
 }

--- a/slocLoader/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
+++ b/slocLoader/TriggerActions/Data/SerializableTeleportToSpawnedObjectData.cs
@@ -13,13 +13,20 @@ public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionD
 
     public readonly Vector3 Offset;
 
+    public readonly float RotationY;
+
     public readonly TeleportOptions Options;
 
-    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options)
+    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options) : this(id, offset, options, 0)
+    {
+    }
+
+    public SerializableTeleportToSpawnedObjectData(int id, Vector3 offset, TeleportOptions options, float rotationY)
     {
         ID = id;
         Offset = offset;
         Options = options;
+        RotationY = rotationY;
     }
 
     protected override void WriteData(BinaryWriter writer)
@@ -27,6 +34,7 @@ public sealed class SerializableTeleportToSpawnedObjectData : BaseTriggerActionD
         writer.Write(ID);
         writer.WriteVector(Offset);
         writer.Write((byte) Options);
+        writer.Write(RotationY);
     }
 
 }

--- a/slocLoader/TriggerActions/Enums/TeleportOptions.cs
+++ b/slocLoader/TriggerActions/Enums/TeleportOptions.cs
@@ -8,6 +8,7 @@ public enum TeleportOptions : byte
     ResetFallDamage = 1,
     ResetVelocity = 2,
     WorldSpaceTransform = 4,
-    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform
+    DeltaRotation = 8,
+    All = ResetFallDamage | ResetVelocity | WorldSpaceTransform | DeltaRotation
 
 }

--- a/slocLoader/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
+++ b/slocLoader/TriggerActions/Handlers/Abstract/TeleportHandlerBase.cs
@@ -1,0 +1,63 @@
+using AdminToys;
+using InventorySystem.Items.Pickups;
+using PlayerRoles.Ragdolls;
+using slocLoader.TriggerActions.Data;
+using slocLoader.TriggerActions.Enums;
+
+namespace slocLoader.TriggerActions.Handlers.Abstract;
+
+public abstract class TeleportHandlerBase<TData> : UniversalTriggerActionHandler<TData> where TData : BaseTeleportData
+{
+
+    protected override bool ValidateData(GameObject interactingObject, TData data, TriggerListener listener)
+        => !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
+
+    protected override void HandlePlayer(ReferenceHub player, TData data, TriggerListener listener)
+    {
+        if (TryCalculateTransform(player, data, out var pos, out var rotation))
+            player.OverridePosition(pos, data.Options & ~TeleportOptions.DeltaRotation, rotation.eulerAngles.y);
+    }
+
+    protected override void HandleItem(ItemPickupBase pickup, TData data, TriggerListener listener)
+    {
+        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
+        HandleComponent(pickup, data);
+    }
+
+    protected override void HandleToy(AdminToyBase toy, TData data, TriggerListener listener) => HandleComponent(toy, data);
+
+    protected override void HandleRagdoll(BasicRagdoll ragdoll, TData data, TriggerListener listener)
+    {
+        if (TryCalculateTransform(ragdoll, data, out var pos, out var rotation))
+            TriggerActionHelpers.SetRagdollPositionAndRotation(ragdoll, pos, rotation);
+    }
+
+    protected abstract Transform GetReferenceTransform(Component component, TData data);
+
+    protected bool TryCalculateTransform(Component component, TData data, out Vector3 position, out Quaternion rotation)
+    {
+        Transform reference = GetReferenceTransform(component, data);
+        float y;
+        if (reference)
+            data.ToWorldSpace(reference, out position, out y);
+        else
+        {
+            position = data.Position;
+            y = data.RotationY;
+        }
+
+        var euler = component.transform.eulerAngles;
+        rotation = Quaternion.Euler(euler.x, data.Options.HasFlagFast(TeleportOptions.DeltaRotation) ? euler.y + data.RotationY : y, euler.z);
+        return true;
+    }
+
+    protected void HandleComponent(Component component, TData data)
+    {
+        if (!TryCalculateTransform(component, data, out var pos, out var rotation))
+            return;
+        var t = component.transform;
+        t.position = pos;
+        t.rotation = rotation;
+    }
+
+}

--- a/slocLoader/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
+++ b/slocLoader/TriggerActions/Handlers/MoveRelativeToSelfHandler.cs
@@ -1,45 +1,14 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class MoveRelativeToSelfHandler : UniversalTriggerActionHandler<MoveRelativeToSelfData>
+public sealed class MoveRelativeToSelfHandler : TeleportHandlerBase<MoveRelativeToSelfData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.MoveRelativeToSelf;
 
-    protected override bool ValidateData(GameObject interactingObject, MoveRelativeToSelfData data, TriggerListener listener) =>
-        !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        if (!player.TryGetMovementModule(out var module))
-            return;
-        var offset = !data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform) ? player.PlayerCameraReference.rotation * data.Position : data.Position;
-        if (data.Options.HasFlagFast(TeleportOptions.ResetFallDamage))
-            module.Motor.ResetFallDamageCooldown();
-        module.ServerOverridePosition(module.Position + offset, Vector3.zero);
-    }
-
-    protected override void HandleItem(ItemPickupBase pickup, MoveRelativeToSelfData data, TriggerListener listener)
-    {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, MoveRelativeToSelfData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, MoveRelativeToSelfData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.ToWorldSpacePosition(ragdoll.transform));
-
-    private static void HandleComponent(Component component, MoveRelativeToSelfData data)
-    {
-        var t = component.transform;
-        t.position = data.ToWorldSpacePosition(t);
-    }
+    protected override Transform GetReferenceTransform(Component component, MoveRelativeToSelfData data) => component.transform;
 
 }

--- a/slocLoader/TriggerActions/Handlers/TeleportToPositionHandler.cs
+++ b/slocLoader/TriggerActions/Handlers/TeleportToPositionHandler.cs
@@ -1,34 +1,14 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToPositionHandler : UniversalTriggerActionHandler<TeleportToPositionData>
+public sealed class TeleportToPositionHandler : TeleportHandlerBase<TeleportToPositionData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToPosition;
 
-    protected override bool ValidateData(GameObject interactingObject, TeleportToPositionData data, TriggerListener listener) =>
-        !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, TeleportToPositionData data, TriggerListener listener) =>
-        player.OverridePosition(data.Position, data.Options);
-
-    protected override void HandleItem(ItemPickupBase pickup, TeleportToPositionData data, TriggerListener listener)
-    {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, TeleportToPositionData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, TeleportToPositionData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.Position);
-
-    private static void HandleComponent(Component component, TeleportToPositionData data) => component.transform.position = data.Position;
+    protected override Transform GetReferenceTransform(Component component, TeleportToPositionData data) => null;
 
 }

--- a/slocLoader/TriggerActions/Handlers/TeleportToRoomHandler.cs
+++ b/slocLoader/TriggerActions/Handlers/TeleportToRoomHandler.cs
@@ -1,61 +1,16 @@
-﻿using AdminToys;
-using Axwabo.Helpers.Config;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
+﻿using Axwabo.Helpers.Config;
 using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToRoomHandler : UniversalTriggerActionHandler<TeleportToRoomData>
+public sealed class TeleportToRoomHandler : TeleportHandlerBase<TeleportToRoomData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToRoom;
 
-    protected override bool ValidateData(GameObject interactingObject, TeleportToRoomData data, TriggerListener listener) =>
-        !string.IsNullOrWhiteSpace(data.Room) && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
-
-    protected override void HandlePlayer(ReferenceHub player, TeleportToRoomData data, TriggerListener listener)
-    {
-        if (TryCalculatePosition(data, out var pos))
-            player.OverridePosition(pos, data.Options);
-    }
-
-    protected override void HandleItem(ItemPickupBase pickup, TeleportToRoomData data, TriggerListener listener)
-    {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, TeleportToRoomData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, TeleportToRoomData data, TriggerListener listener)
-    {
-        if (TryCalculatePosition(data, out var pos))
-            TriggerActionHelpers.SetRagdollPosition(ragdoll, pos);
-    }
-
-    private static bool TryCalculatePosition(TeleportToRoomData data, out Vector3 vector)
-    {
-        var point = new MapPointByName(data.Room, data.Position);
-        if (!data.Options.HasFlagFast(TeleportOptions.WorldSpaceTransform))
-            return point.TryGetWorldPose(out vector, out _);
-        var transform = point.RoomTransform();
-        if (!transform)
-        {
-            vector = Vector3.zero;
-            return false;
-        }
-
-        vector = transform.position + data.Position;
-        return true;
-    }
-
-    private static void HandleComponent(Component component, TeleportToRoomData data)
-    {
-        if (TryCalculatePosition(data, out var pos))
-            component.transform.position = pos;
-    }
+    protected override Transform GetReferenceTransform(Component component, TeleportToRoomData data)
+        => ConfigHelper.GetRoomByRoomName(data.Room).SafeGetTransform();
 
 }

--- a/slocLoader/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
+++ b/slocLoader/TriggerActions/Handlers/TeleportToSpawnedObjectHandler.cs
@@ -1,35 +1,17 @@
-﻿using AdminToys;
-using InventorySystem.Items.Pickups;
-using PlayerRoles.Ragdolls;
-using slocLoader.TriggerActions.Data;
+﻿using slocLoader.TriggerActions.Data;
 using slocLoader.TriggerActions.Enums;
 using slocLoader.TriggerActions.Handlers.Abstract;
 
 namespace slocLoader.TriggerActions.Handlers;
 
-public sealed class TeleportToSpawnedObjectHandler : UniversalTriggerActionHandler<RuntimeTeleportToSpawnedObjectData>
+public sealed class TeleportToSpawnedObjectHandler : TeleportHandlerBase<RuntimeTeleportToSpawnedObjectData>
 {
 
     public override TriggerActionType ActionType => TriggerActionType.TeleportToSpawnedObject;
 
-    protected override bool ValidateData(GameObject interactingObject, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        data.Target != null && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
+    protected override bool ValidateData(GameObject interactingObject, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener)
+        => data.Target != null && !TeleporterImmunityStorage.IsImmune(interactingObject, listener);
 
-    protected override void HandlePlayer(ReferenceHub player, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        player.OverridePosition(data.ToWorldSpacePosition(data.Target.transform), data.Options);
-
-    protected override void HandleItem(ItemPickupBase pickup, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener)
-    {
-        TriggerActionHelpers.ResetVelocityOfPickup(pickup, data.Options);
-        HandleComponent(pickup, data);
-    }
-
-    protected override void HandleToy(AdminToyBase toy, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) => HandleComponent(toy, data);
-
-    protected override void HandleRagdoll(BasicRagdoll ragdoll, RuntimeTeleportToSpawnedObjectData data, TriggerListener listener) =>
-        TriggerActionHelpers.SetRagdollPosition(ragdoll, data.ToWorldSpacePosition(data.Target.transform));
-
-    private static void HandleComponent(Component component, RuntimeTeleportToSpawnedObjectData data) =>
-        component.transform.position = data.ToWorldSpacePosition(data.Target.transform);
+    protected override Transform GetReferenceTransform(Component component, RuntimeTeleportToSpawnedObjectData data) => data.Target.transform;
 
 }

--- a/slocLoader/TriggerActions/Handlers/TriggerActionHelpers.cs
+++ b/slocLoader/TriggerActions/Handlers/TriggerActionHelpers.cs
@@ -10,11 +10,15 @@ namespace slocLoader.TriggerActions.Handlers;
 public static class TriggerActionHelpers
 {
 
-    public static void SetRagdollPosition(BasicRagdoll ragdoll, Vector3 targetPosition)
+    public static void SetRagdollPosition(BasicRagdoll ragdoll, Vector3 targetPosition) => SetRagdollPositionAndRotation(ragdoll, targetPosition, Quaternion.identity);
+
+    public static void SetRagdollPositionAndRotation(BasicRagdoll ragdoll, Vector3 targetPosition, Quaternion targetRotation)
     {
         if (!slocPlugin.Instance.Config.EnableRagdollPositionModification)
             return;
-        ragdoll.transform.position = targetPosition;
+        var t = ragdoll.transform;
+        t.position = targetPosition;
+        t.rotation = targetRotation;
         var identity = ragdoll.netIdentity;
         foreach (var hub in ReferenceHub.AllHubs)
             if (hub.connectionToClient != null)
@@ -29,6 +33,7 @@ public static class TriggerActionHelpers
         {
             case PickupStandardPhysics physics:
                 physics.Rb.velocity = Vector3.zero;
+                physics.Rb.angularVelocity = Vector3.zero;
                 break;
             case Scp018Physics scp018:
                 scp018._lastVelocity = Vector3.zero;
@@ -48,13 +53,19 @@ public static class TriggerActionHelpers
         return true;
     }
 
-    public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options)
+    public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options = TeleportOptions.ResetFallDamage)
+        => hub.OverridePosition(position, options | TeleportOptions.DeltaRotation, 0);
+
+    public static void OverridePosition(this ReferenceHub hub, Vector3 position, TeleportOptions options, float rotation)
     {
         if (!hub.TryGetMovementModule(out var module))
             return;
         if (options.HasFlagFast(TeleportOptions.ResetFallDamage))
             module.Motor.ResetFallDamageCooldown();
-        module.ServerOverridePosition(position, Vector3.zero);
+        var delta = options.HasFlagFast(TeleportOptions.DeltaRotation)
+            ? rotation
+            : rotation - module.MouseLook.CurrentHorizontal;
+        module.ServerOverridePosition(position, new Vector3(0, delta, 0));
     }
 
 }

--- a/slocLoader/TriggerActions/Readers/Ver5ActionDataReader.cs
+++ b/slocLoader/TriggerActions/Readers/Ver5ActionDataReader.cs
@@ -1,0 +1,62 @@
+using slocLoader.TriggerActions.Data;
+using slocLoader.TriggerActions.Enums;
+
+namespace slocLoader.TriggerActions.Readers;
+
+public sealed class Ver5ActionDataReader : ITriggerActionDataReader
+{
+
+    public BaseTriggerActionData Read(BinaryReader reader)
+    {
+        ActionManager.ReadTypes(reader, out var actionType, out var targetType, out var eventType);
+        BaseTriggerActionData data = actionType switch
+        {
+            TriggerActionType.TeleportToPosition => ReadTpToPos(reader),
+            TriggerActionType.MoveRelativeToSelf => ReadMoveRelative(reader),
+            TriggerActionType.TeleportToRoom => ReadTpToRoom(reader),
+            TriggerActionType.KillPlayer => Ver4ActionDataReader.ReadKillPlayer(reader),
+            TriggerActionType.TeleportToSpawnedObject => ReadTpToSpawnedObject(reader),
+            TriggerActionType.TeleporterImmunity => Ver4ActionDataReader.ReadTeleporterImmunity(reader),
+            _ => null
+        };
+        if (data is null)
+            return null;
+        data.SelectedTargets = targetType;
+        data.SelectedEvents = eventType;
+        return data;
+    }
+
+    public static TeleportToPositionData ReadTpToPos(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        return new TeleportToPositionData(position) {Options = options, RotationY = rotation};
+    }
+
+    public static MoveRelativeToSelfData ReadMoveRelative(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        return new MoveRelativeToSelfData(position) {Options = options, RotationY = rotation};
+    }
+
+    public static TeleportToRoomData ReadTpToRoom(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var position, out var options, out var rotation);
+        var name = reader.ReadString();
+        return new TeleportToRoomData(name, position) {Options = options, RotationY = rotation};
+    }
+
+    public static SerializableTeleportToSpawnedObjectData ReadTpToSpawnedObject(BinaryReader reader)
+    {
+        ReadTeleportData(reader, out var offset, out var options, out var rotation);
+        var virtualInstanceId = reader.ReadInt32();
+        return new SerializableTeleportToSpawnedObjectData(virtualInstanceId, offset, options, rotation);
+    }
+
+    public static void ReadTeleportData(BinaryReader reader, out Vector3 position, out TeleportOptions options, out float rotation)
+    {
+        position = reader.ReadVector();
+        options = (TeleportOptions) reader.ReadByte();
+        rotation = reader.ReadSingle();
+    }
+
+}

--- a/slocLoader/slocLoader.csproj
+++ b/slocLoader/slocLoader.csproj
@@ -112,6 +112,7 @@
         <Compile Include="Commands\ReloadCommand.cs"/>
         <Compile Include="Commands\RotationCommand.cs"/>
         <Compile Include="Commands\SpawnCommand.cs"/>
+        <Compile Include="Commands\StructureCommand.cs"/>
         <Compile Include="GlobalUsings.cs"/>
         <Compile Include="InstanceDictionary.cs"/>
         <Compile Include="Objects\EmptyObject.cs"/>

--- a/slocLoader/slocLoader.csproj
+++ b/slocLoader/slocLoader.csproj
@@ -130,6 +130,7 @@
         <Compile Include="Readers\Ver3Reader.cs"/>
         <Compile Include="Readers\Ver4Reader.cs"/>
         <Compile Include="Readers\Ver5Reader.cs"/>
+        <Compile Include="SendSpawnMessagePatch.cs"/>
         <Compile Include="SetPrimitiveTypePatch.cs"/>
         <Compile Include="slocAttributes.cs"/>
         <Compile Include="slocConfig.cs"/>

--- a/slocLoader/slocLoader.csproj
+++ b/slocLoader/slocLoader.csproj
@@ -122,12 +122,14 @@
         <Compile Include="Objects\slocTransform.cs"/>
         <Compile Include="ObjectCreation\ObjectsSource.cs"/>
         <Compile Include="ObjectCreation\CreateOptions.cs"/>
+        <Compile Include="Objects\StructureObject.cs"/>
         <Compile Include="Readers\IObjectReader.cs"/>
         <Compile Include="Readers\slocHeader.cs"/>
         <Compile Include="Readers\Ver1Reader.cs"/>
         <Compile Include="Readers\Ver2Reader.cs"/>
         <Compile Include="Readers\Ver3Reader.cs"/>
         <Compile Include="Readers\Ver4Reader.cs"/>
+        <Compile Include="Readers\Ver5Reader.cs"/>
         <Compile Include="SetPrimitiveTypePatch.cs"/>
         <Compile Include="slocAttributes.cs"/>
         <Compile Include="slocConfig.cs"/>

--- a/slocLoader/slocLoader.csproj
+++ b/slocLoader/slocLoader.csproj
@@ -155,6 +155,7 @@
         <Compile Include="TriggerActions\Handlers\Abstract\PickupActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\PlayerActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\RagdollActionHandler.cs"/>
+        <Compile Include="TriggerActions\Handlers\Abstract\TeleportHandlerBase.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\ToyActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\Abstract\UniversalTriggerActionHandler.cs"/>
         <Compile Include="TriggerActions\Handlers\ITriggerActionHandler.cs"/>
@@ -167,6 +168,7 @@
         <Compile Include="TriggerActions\Handlers\TriggerActionHelpers.cs"/>
         <Compile Include="TriggerActions\Readers\ITriggerActionDataReader.cs"/>
         <Compile Include="TriggerActions\Readers\Ver4ActionDataReader.cs"/>
+        <Compile Include="TriggerActions\Readers\Ver5ActionDataReader.cs"/>
         <Compile Include="TriggerActions\TeleporterImmunityStorage.cs"/>
         <Compile Include="TriggerActions\TriggerListener.cs"/>
         <Compile Include="TriggerActions\TriggerListenerInvoker.cs"/>

--- a/slocLoader/slocPlugin.cs
+++ b/slocLoader/slocPlugin.cs
@@ -15,8 +15,8 @@ public sealed class slocPlugin : Plugin<slocConfig>
     public override string Name => "slocLoader";
     public override string Prefix => "sloc";
     public override string Author => "Axwabo";
-    public override PluginPriority Priority => PluginPriority.Lower;
-    public override Version Version { get; } = new(4, 2, 4);
+    public override PluginPriority Priority => PluginPriority.High;
+    public override Version Version { get; } = new(5, 0, 0);
     public override Version RequiredExiledVersion { get; } = new(8, 4, 0);
 
     private Harmony _harmony;


### PR DESCRIPTION
# Additions:

- `StructureObject`
- `Ver5Reader`
- `API.StructurePrefabIds` dictionary
- Teleport rotation (`RotationY` property in `BaseTeleportData`)
- `BaseTeleportData::ToWorldSpace(Transform, out Vector3, out float)`
- `SerializableTeleportToSpawnedObjectData.RotationY` field with constructor
- `TriggerActionHelpers::SetRagdollPositionAndRotation(BasicRagdoll, Vector3, Quaternion)`
- `TriggerActionHelpers::OverridePosition(this ReferenceHub, Vector3, TeleportOptions, float)`
- `Ver5ActionDataReader`
- `TeleportHandlerBase<TData>`
- `sl_structure` command

# Changes (non-breaking):

- Changed plugin priority to `High` (EXILED only)
- Changed the default value of the `options` argument in `TriggerActionHelpers::OverridePosition(this ReferenceHub, Vector3, TeleportOptions` to `TeleportOptions.ResetFallDamage`
- The default value of `BaseTeleportData.Options` is now `ResetFallDamage | DeltaRotation`
- `ActionManager::Is(this TeleportOptions, TeleportOptions)` no longer returns true when the type is `TeleportOptions.None`
- Made the following classes extend the newly added `TeleportHandlerBase<TData>`
  - `MoveRelativetoSelfHandler`
  - `TeleportToRoomHandler`
  - `TeleportToPositionHandler`
  - `TeleportToSpawnedObjectHandler`
- The `sl_rl` command can now be executed from the Remote Admin and requires the `ServerConfigs` permission